### PR TITLE
Use node-fetch instead of wumpfetch

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const wump = require('wumpfetch');
+const fetch = require('node-fetch');
 
 module.exports = class Boats {
   constructor(token, version) {
@@ -10,8 +10,8 @@ module.exports = class Boats {
     if (typeof botid !== 'string') throw new TypeError('Bot ID must be a string');
     return new Promise(async (resolve, reject) => {
       try {
-         const res = await wump(`https://discord.boats/api/${this.version}/bot/${botid}`).send();
-         resolve(res.json());
+         const res = await fetch(`https://discord.boats/api/${this.version}/bot/${botid}`);
+         resolve(await res.json());
       } catch (err) { reject(new Error(err)); }
     });
   }
@@ -21,8 +21,8 @@ module.exports = class Boats {
     if (typeof botid !== 'string') throw new TypeError('Bot ID must be a string');
     return new Promise(async (resolve, reject) => {
       try {
-         const res = await wump(`https://discord.boats/api/${this.version}/bot/${botid}/voted?id=${userid}`).send();
-         resolve(res.json());
+         const res = await fetch(`https://discord.boats/api/${this.version}/bot/${botid}/voted?id=${userid}`);
+         resolve(await res.json());
       } catch (err) { reject(new Error(err)); }
     });
   }
@@ -31,8 +31,8 @@ module.exports = class Boats {
     if (typeof userid !== 'string') throw new TypeError('User ID must be a string');
     return new Promise(async (resolve, reject) => {
       try {
-         const res = await wump(`https://discord.boats/api/${this.version}/user/${userid}`).send();
-         resolve(res.json());
+         const res = await fetch(`https://discord.boats/api/${this.version}/user/${userid}`);
+         resolve(await res.json());
       } catch (err) { reject(new Error(err)); }
     });
   }
@@ -43,12 +43,12 @@ module.exports = class Boats {
     if (typeof botid !== 'string') throw new TypeError('Bot ID must be a string');
     return new Promise(async (resolve, reject) => {
       try {
-         const res = await wump(`https://discord.boats/api/${this.version}/bot/${botid}`, {
+         const res = await fetch(`https://discord.boats/api/${this.version}/bot/${botid}`, {
           method: 'POST', 
           headers: { 'Authorization': this.token },
-          data: { 'server_count': servercount  }
-        }).send();
-        resolve(res.json());
+          body: { 'server_count': servercount  }
+        });
+        resolve(await res.json());
       } catch (err) { reject(new Error(err)); }
     });
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "boats.js",
+  "version": "2.3.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,5 @@
     "url": "git+https://github.com/DiscordBoats/boats.js.git"
   },
   "version": "2.3.0",
-  "dependencies": {
-    "wumpfetch": "^0.2.13"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Node fetch is integrated with nodejs which allows to remove wumpfetch from dependencies. Wumpus says it is a few milliseconds faster but I find that having a project without dependency and using a package made by node is better than overloading with another package to gain an unnecessary millisecond...